### PR TITLE
Quick Fixes and Improvements - Linux Support, Auto Highlight mode, Handling Missing JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ If you would like to Highlight the EPUB version, reorder it to be the first path
    }
 ]
 ```
+2. You can manually specify the path to `calibredb` with the environmental variable `CALIBREDB_BIN`, e.g. `CALIBREDB_BIN=/usr/bin/calibredb python main.py`. By default it will by `calibredb` or for Windows `calibredb.exe`.
+3. You can disable the manual approval of each highlight with the environmental variable `HIGHLIGHT_AUTO_APPLY`, e.g. `HIGHLIGHT_AUTO_APPLY=true python main.py` By default it is enabled.
+4. If you use `HIGHLIGHT_AUTO_APPLY` some or all highlights are missing, try setting `HIGHLIGHT_AUTO_APPLY_DEFAULT_SLEEP` to a value greater than one (second), e.g. `HIGHLIGHT_AUTO_APPLY_DEFAULT_SLEEP=2 HIGHLIGHT_AUTO_APPLY=true main.py`. This will increase the duration between each highlight, in case Calibre cannot keep up.
 
 ### Future Enhancements
 


### PR DESCRIPTION
I added a few quick fixes to the script:

- Support for Linux (and probably Mac).
  - Should autodetect Windows and add the `.exe` to the binary name
  - Can manually set the path to `calibredb` with the `CALIBREDB_BIN` environmental variable
- Allow skipping highlight approval with the `HIGHLIGHT_AUTO_APPLY` variable
  - Can also manually set the delay (default one second) before moving to the next highlight with `HIGHLIGHT_AUTO_APPLY_DEFAULT_SLEEP`
- Handle missing `json` files more gracefully by creating an empty dict rather than failing
- Update the `README.md` with new tips for using environmental variables

I don't have a Windows system to test this on but it should work just fine according to [the os.name docs](https://docs.python.org/3/library/os.html#os.name). I have however tested it a bit on Debian, with multiple env var configurations to make sure it all seems to work as expected.